### PR TITLE
precompile fewer wheels

### DIFF
--- a/base/wheels/Dockerfile
+++ b/base/wheels/Dockerfile
@@ -70,34 +70,4 @@ RUN pip wheel \
   netcdf4 \
   && true
 
-RUN pip wheel \
-  --no-cache-dir \
-  --no-binary=:all:  \
-  --no-build-isolation \
-  --no-deps \
-  pyyaml \
-  ruamel.yaml \
-  ruamel.yaml.clib \
-  pyrsistent \
-  cffi \
-  cftime \
-  ciso8601 \
-  psycopg2 \
-  && true
-
-RUN echo "Building jupyter related libs" \
-  && pip wheel \
-  --no-cache-dir \
-  --no-binary=:all:  \
-  --no-build-isolation \
-  --no-deps \
-  pyzmq \
-  msgpack \
-  tornado \
-  yarl \
-  multidict \
-  aiohttp \
-  MarkupSafe \
-  && true
-
 COPY env-build-tool /usr/local/bin/

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,6 +1,6 @@
 # misc
 aiobotocore[boto3,awscli]==0.11.1
-pyyaml==5.2
+pyyaml==5.1.2
 python-dateutil==2.8.0
 colorama
 cython

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,8 +1,9 @@
 # misc
-aiobotocore[boto3,awscli]==0.11.0
+aiobotocore[boto3,awscli]==0.11.1
+pyyaml==5.2
 python-dateutil==2.8.0
+colorama
 cython
-pyyaml
 ruamel.yaml
 pyrsistent
 ciso8601


### PR DESCRIPTION
Basically pre-compiled wheels are more trouble then they worth as they pin versions, so only do it for geo libs.