### PR TITLE
Adds constraints to pin package versions and bump to 4.0.0

### DIFF
--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -13,7 +13,7 @@ env:
   ORG: opendatacube
   IMAGE: geobase
   DOCKER_USER: gadockersvc
-  V: 3.0.5
+  V: 4.0.0
 
 
 jobs:

--- a/base/wheels/Dockerfile
+++ b/base/wheels/Dockerfile
@@ -14,11 +14,14 @@ RUN echo "GDAL==$(gdal-config --version)" > /tmp/constraints.txt \
   GDAL \
   && rm /tmp/constraints.txt
 
+COPY ./constraints.txt constraints.txt
+
 RUN pip3 wheel \
   --no-cache-dir \
   --no-binary=:all:  \
   --no-build-isolation \
   --no-deps \
+  -c /wheels/constraints.txt \
   netcdf4 \
   && rm -rf ~/.cache/pip
 
@@ -26,6 +29,7 @@ RUN pip3 wheel \
   --no-cache-dir \
   --no-binary=h5py  \
   --no-deps \
+  -c /wheels/constraints.txt \
   h5py \
   && rm -rf ~/.cache/pip
 
@@ -34,6 +38,7 @@ RUN pip3 wheel \
   --no-binary=:all:  \
   --no-build-isolation \
   --no-deps \
+  -c /wheels/constraints.txt \
   tables \
   && rm -rf ~/.cache/pip
 
@@ -43,6 +48,7 @@ RUN CFLAGS="-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1" \
   --no-binary=:all: \
   --no-build-isolation \
   --no-deps \
+  -c /wheels/constraints.txt \
   cartopy
 
 RUN pip3 wheel \
@@ -50,6 +56,7 @@ RUN pip3 wheel \
   --no-binary=:all: \
   --no-build-isolation \
   --no-deps \
+  -c /wheels/constraints.txt \
   fiona
 
 RUN pip3 wheel \
@@ -57,6 +64,7 @@ RUN pip3 wheel \
   --no-binary=:all: \
   --no-build-isolation \
   --no-deps \
+  -c /wheels/constraints.txt \
   shapely
 
 RUN pip3 wheel \
@@ -64,14 +72,17 @@ RUN pip3 wheel \
   --no-binary=:all: \
   --no-build-isolation \
   --no-deps \
-  'pyproj==2.6.*'
+  -c /wheels/constraints.txt \
+  pyproj
 
 RUN pip3 wheel \
   --no-cache-dir \
   --no-binary=:all: \
   --no-build-isolation \
   --no-deps \
-  rasterio==1.1.6
+  -c /wheels/constraints.txt \
+  rasterio
 
+RUN rm constraints.txt
 
 COPY env-build-tool /usr/local/bin/

--- a/base/wheels/constraints.txt
+++ b/base/wheels/constraints.txt
@@ -1,0 +1,8 @@
+netcdf4==1.5.5
+h5py==3.1.0
+tables==3.6.1
+cartopy==0.18.0
+fiona==1.8.18
+shapely==1.7.1
+pyproj==2.6.*
+rasterio==1.1.6


### PR DESCRIPTION
#### What does this PR do?

Adds a constraints file for wheels python packages.
Decouple from GDAL versioning.
Bump to version 4.0.0.
Fixes CVE CRITICAL / HIGH vulnerabilities.

- [x ] CVE fix
