### PR TITLE
Tweak release workflow

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,11 +1,7 @@
 name: build
 
-# Edit line below to force a rebuild (will still use cache though, unless base
-# image changed)
-#
-# Bump: 25-Feb-2021
-
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'stable-**'

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'stable-**'
@@ -24,13 +25,20 @@ jobs:
 
     - name: Base Image (builder)
       run: |
-        docker build --tag ${ORG}/${IMAGE}-builder:${V} ./base/builder
+        docker pull ${ORG}/${IMAGE}-builder:latest
+        docker build \
+          --cache-from ${ORG}/${IMAGE}-builder:latest \
+          --tag ${ORG}/${IMAGE}-builder:${V} \
+          ./base/builder
 
     - name: Base Image (runner)
       run: |
+        docker pull ${ORG}/${IMAGE}-runner:latest
         docker build \
+          --cache-from ${ORG}/${IMAGE}-runner:latest \
+          --tag ${ORG}/${IMAGE}-runner:${V} \
           --build-arg base=${ORG}/${IMAGE}-builder:${V} \
-          --tag ${ORG}/${IMAGE}-runner:${V} ./base/runner
+          ./base/runner
 
     - name: DockerHub Push
       run: |


### PR DESCRIPTION
- build release images using `:latest` as cache
- add manual trigger hook (useful when base image changed due to CVE fixes)