### PR TITLE
Supporting incremental and parallel building of `./wheels`

### DIFF
--- a/base/builder/Dockerfile
+++ b/base/builder/Dockerfile
@@ -137,6 +137,7 @@ ENTRYPOINT ["/bin/tini", "-s", "--", "/usr/local/bin/with_bootstrap"]
 COPY assets/requirements-base.txt /conf/requirements-base.txt
 COPY assets/nobinary.txt /conf/nobinary.txt
 COPY assets/env-build-tool /usr/local/bin/env-build-tool
+COPY assets/compile-wheels.mk /opt/
 RUN echo "GDAL==$(gdal-config --version)" > /opt/constraints-gdal.txt \
     && mkdir -p /wk \
     && env-build-tool new /conf/requirements-base.txt /dev/null /opt/env0 \

--- a/base/builder/Dockerfile
+++ b/base/builder/Dockerfile
@@ -62,6 +62,8 @@ RUN apt-get update -y \
     libudunits2-dev \
     libgeos-dev \
     libgeos++-dev \
+    pybind11-dev \
+    libeigen3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # dev conveniences

--- a/base/builder/assets/compile-wheels.mk
+++ b/base/builder/assets/compile-wheels.mk
@@ -1,0 +1,34 @@
+#
+# - Finds any source distribution files in current directory
+# - Compiles each one into a wheel
+# - Generates `.done` file containing name of the wheel that was built
+pip ?= /opt/env0/bin/python -m pip
+srcs := $(wildcard *.zip *.tar.gz *.tar *.tar.Z *.tar.xz *.tar.bz2 *.tgz *.tbz)
+out := $(patsubst %, %.done, $(srcs))
+extra ?=
+
+all: $(out)
+
+%.done: %
+	@echo "Processing: " $<
+	@(tt=$$(mktemp -d "/tmp/wheel-build-XXXX") && \
+   echo ".. working in " $${tt} && \
+	 $(pip) wheel --no-deps -w $${tt} $(extra) $< && \
+   whl=$$(find $${tt} -name "*.whl") && \
+   mv $${whl} ./ && \
+   echo $$(basename $${whl}) | tee $@ && \
+   rmdir $${tt} \
+  )
+
+dbg:
+	@echo "sources:" $(srcs)
+	@echo "out:" $(out)
+	@echo "pip:" $(pip)
+
+list:
+	@find . -name "*.done" | xargs cat
+
+clean:
+	rm *.done
+
+.PHONY: dbg all clean list

--- a/base/builder/assets/env-build-tool
+++ b/base/builder/assets/env-build-tool
@@ -46,6 +46,31 @@ get_nobinary_cmdline () {
     fi
 }
 
+# download wheels/sorces from requirements.txt and constraints
+#   wheels that are in /wheels will be copied through and not re-compiled
+cmd_download () {
+    local requirements="${1:-/conf/requirements.txt}"
+    local constraints="${2:-/conf/constraints.txt}"
+    local dst_wheels="${3:-/wheels}"
+
+    local pip="${ENV0}/bin/python -m pip"
+
+    if [[ $# < 3 ]]; then
+        shift $#
+    else
+        shift 3
+    fi
+
+    $pip download \
+         --constraint="${CC_GDAL}" \
+         --constraint="${constraints}" \
+         --requirement="${requirements}" \
+         --dest="${dst_wheels}" \
+         --no-build-isolation \
+         $(get_nobinary_cmdline) \
+         $@
+}
+
 # download/compile wheels from requirements.txt
 #   wheels that are in /wheels will be copied through and not re-compiled
 cmd_wheels () {
@@ -184,7 +209,7 @@ cmd_help () {
     echo 'env-build-tool <wheels|new|new_no_index|extend|help> ARGS
 
 Download or compile the required wheels into `wheel_dir`
-  > env-build-tool wheels <requirements.txt> <constraints.txt> <wheel_dir:/wheels> <other-args-for-pip>
+  > env-build-tool download|wheels <requirements.txt> <constraints.txt> <wheel_dir:/wheels> <other-args-for-pip>
 
 Make a new python environment from the requirements and constraints
   > env-build-tool new <requirements.txt> <constraints.txt> <env:/env> <other-args-for-pip>
@@ -209,7 +234,7 @@ cmd_main () {
    shift || true # Always succeed, so that we display help text on no args
 
    case "${cmd}" in
-       wheels|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
+       wheels|download|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
            "cmd_${cmd}" $@
            ;;
        *)

--- a/base/builder/assets/env-build-tool
+++ b/base/builder/assets/env-build-tool
@@ -153,7 +153,7 @@ cmd_new_no_index () {
         shift 4
     fi
 
-    cmd_new $requirements $constraints $env --find-links="${wheels}" --no-index
+    NOBINARY=/dev/null cmd_new $requirements $constraints $env --find-links="${wheels}" --no-index
 }
 
 

--- a/base/builder/assets/env-build-tool
+++ b/base/builder/assets/env-build-tool
@@ -21,20 +21,24 @@ uncomment () {
     print $0}'
 }
 
+# if BINARY_ONLY=yes print nothing
 #
-# 1. NOBINARY pointing to a file
-# 2. NOBINARY with embedded content
-# 3. /conf/nobinary.txt
+# - /conf/nobinary.txt (if exists)
+# - $NOBINARY pointing to a file
+# - $NOBINARY with embedded content
 get_nobinary () {
-    if [ -n "${NOBINARY:-}" ]; then
-        if [ -f "${NOBINARY}" ]; then
-            uncomment < "${NOBINARY}"
+    local nobin="${NOBINARY:-}"
+    if [ "${BINARY_ONLY:-}" = "yes" ]; then
+        return 0
+    fi
+
+    [[ ! -e /conf/nobinary.txt ]] || uncomment < /conf/nobinary.txt
+
+    if [ -n "${nobin}" ]; then
+        if [ -f "${nobin}" ]; then
+            uncomment < "${nobin}"
         else
-            echo "${NOBINARY}" | uncomment
-        fi
-    else
-        if [ -f /conf/nobinary.txt ]; then
-            uncomment < /conf/nobinary.txt
+            echo "${nobin}" | uncomment
         fi
     fi
 }
@@ -153,7 +157,7 @@ cmd_new_no_index () {
         shift 4
     fi
 
-    NOBINARY=/dev/null cmd_new $requirements $constraints $env --find-links="${wheels}" --no-index
+    BINARY_ONLY=yes cmd_new $requirements $constraints $env --find-links="${wheels}" --no-index
 }
 
 

--- a/base/builder/assets/env-build-tool
+++ b/base/builder/assets/env-build-tool
@@ -7,6 +7,7 @@ set -o nounset
 
 CC_GDAL=/opt/constraints-gdal.txt
 ENV0=/opt/env0
+MK=/opt/compile-wheels.mk
 
 env_bootstrap_libs="pip setuptools wheel"
 
@@ -47,11 +48,10 @@ get_nobinary_cmdline () {
 }
 
 # download wheels/sorces from requirements.txt and constraints
-#   wheels that are in /wheels will be copied through and not re-compiled
 cmd_download () {
     local requirements="${1:-/conf/requirements.txt}"
     local constraints="${2:-/conf/constraints.txt}"
-    local dst_wheels="${3:-/wheels}"
+    local dst_wheels="${3:-./}"
 
     local pip="${ENV0}/bin/python -m pip"
 
@@ -71,14 +71,22 @@ cmd_download () {
          $@
 }
 
-# download/compile wheels from requirements.txt
-#   wheels that are in /wheels will be copied through and not re-compiled
+# compile source files in a directory
+cmd_compile () {
+   local wheels="${1:-/.}"
+   if [[ $# > 0 ]]; then
+       shift 1
+   fi
+
+   make -f "${MK}" -C ${wheels} extra="$@" -j$(nproc)
+}
+
+# 1. download wheels/sources from requirements.txt
+# 2. compile source distributions into wheels
 cmd_wheels () {
     local requirements="${1:-/conf/requirements.txt}"
     local constraints="${2:-/conf/constraints.txt}"
-    local dst_wheels="${3:-/wheels}"
-
-    local pip="${ENV0}/bin/python -m pip"
+    local dst_wheels="${3:-./}"
 
     if [[ $# < 3 ]]; then
         shift $#
@@ -86,22 +94,10 @@ cmd_wheels () {
         shift 3
     fi
 
-    $pip wheel \
-        --constraint="${CC_GDAL}" \
-        --constraint="${constraints}" \
-        --requirement="${requirements}" \
-        --wheel-dir="${dst_wheels}" \
-        $@
-
-    local nobinary_libs=$(get_nobinary)
-    if [ -n "${nobinary_libs}" ]; then
-        echo "Recompiling a set of libs locally"
-        for wheel in $(cmd_list-manylinux-wheels "${dst_wheels}" ${nobinary_libs}); do
-            echo "Processing: $wheel"
-            cmd_pkg-recompile $wheel ${dst_wheels} $@
-            mv "${wheel}" "${wheel}.bk"
-        done
-    fi
+    echo "Downloading wheels/sources"
+    cmd_download "${requirements}" "${constraints}" "${dst_wheels}" $@
+    echo "Compiling sources on $(nproc) core[s]"
+    cmd_compile ${dst_wheels} $@
 }
 
 # Given path to manylinux wheel build local lib instead
@@ -131,11 +127,15 @@ cmd_pkg-recompile () {
 }
 
 cmd_list-manylinux-wheels() {
-    local wheels="${1}"
+    local wheels="${1:-./}"
     shift
-    for lib in $@; do
-        find "${wheels}" -iname "${lib}-"'*manylinux*.whl'
-    done
+    if [[ $# < 1 ]]; then
+        find "${wheels}" -iname "*-"'*manylinux*.whl'
+    else
+        for lib in $@; do
+            find "${wheels}" -iname "${lib}-"'*manylinux*.whl'
+        done
+    fi
 }
 
 
@@ -145,7 +145,7 @@ cmd_new_no_index () {
     local requirements="${1:-/conf/requirements.txt}"
     local constraints="${2:-/conf/constraints.txt}"
     local env="${3:-/env}"
-    local wheels="${4:-/wheels}"
+    local wheels="${4:-./}"
 
     if [[ $# < 4 ]]; then
         shift $#
@@ -209,7 +209,10 @@ cmd_help () {
     echo 'env-build-tool <wheels|new|new_no_index|extend|help> ARGS
 
 Download or compile the required wheels into `wheel_dir`
-  > env-build-tool download|wheels <requirements.txt> <constraints.txt> <wheel_dir:/wheels> <other-args-for-pip>
+  > env-build-tool download|wheels <requirements.txt> <constraints.txt> <wheel_dir:./> <other-args-for-pip>
+
+Compile source distributions in a directory
+  > env-build-tool compile <wheel_dir:./>
 
 Make a new python environment from the requirements and constraints
   > env-build-tool new <requirements.txt> <constraints.txt> <env:/env> <other-args-for-pip>
@@ -218,7 +221,7 @@ Extend existing python environment using requirements and constraints
   > env-build-tool extend <requirements.txt> <constraints.txt> <env:/env> <other-args-for-pip>
 
 Make a new python environment from the requirements and wheels_dir (No Downloads)
-  > env-build-tool new_no_index <requirements.txt> <constraints.txt> <env:/env> <wheel_dir:/wheels> <other-args-for-pip>
+  > env-build-tool new_no_index <requirements.txt> <constraints.txt> <env:/env> <wheel_dir:./> <other-args-for-pip>
 
 Recompile manylinux wheel
   > env-build-tool pkg-recompile <path-to-wheel-file> [<dst_dir>] <other-args-for-pip>
@@ -234,7 +237,7 @@ cmd_main () {
    shift || true # Always succeed, so that we display help text on no args
 
    case "${cmd}" in
-       wheels|download|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
+       wheels|download|compile|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
            "cmd_${cmd}" $@
            ;;
        *)

--- a/base/builder/assets/requirements-base.txt
+++ b/base/builder/assets/requirements-base.txt
@@ -8,3 +8,4 @@ setuptools
 setuptools_scm[toml]
 numpy
 cython
+pip-tools

--- a/base/builder/assets/with_bootstrap
+++ b/base/builder/assets/with_bootstrap
@@ -22,10 +22,10 @@
 export PIP_CACHE_DIR=/wk/.cache/pip
 
 case "${1:-help}" in
-    wheels|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
+    wheels|download|compile|new|extend|pkg-recompile|new_no_index|list-manylinux-wheels|help)
         exec env-build-tool $@
         ;;
-    python)
+    python|python3)
         source /opt/env0/bin/activate
         exec "$@"
         ;;

--- a/readme.md
+++ b/readme.md
@@ -80,3 +80,54 @@ Folder structure:
 Derives from `ubuntu:20.04`, has all the necessary C/C++/Fortran libs installed in non-dev mode to run python wheels compiled in `base/builder`.
 
 It is used as base for "runner dockers" that use multi-stage building technique: builder stage constructs a python environment using pre-compiled wheels + whatever extra downloaded from pypi.
+
+
+## Building Test Environment for your library
+
+You need to supply 3 files
+
+- `requirements.txt` contains top level requirements you need for testing your library (avoid pinning versions in there)
+- `constraints.txt` often it's output of `pip freeze` from a known to work environment (also have a look at `pip-compile` tool)
+- `nobinary.txt` can be empty, contains libraries you prefer to compile locally
+  rather than using `manylinux` wheels from pypi. Note that common geospatial
+  libraries will be compiled to ensure consistent C library usage across those
+  packages regardless of the content of your `nobinary.txt` file. For a full
+  list see `/conf/nobinary.txt` inside the docker.
+
+Put all three files in one folder. Then you can run something like the script
+below to generate wheels and build python environment from that. Wheels and
+sources will be stored in `./wheels` directory, and python environment is
+`./env`, there will also be `.cache/pip` directory.
+
+```bash
+#!/bin/bash
+
+# points to your code on dev/test machine
+# must be an absolute path, hence `readlink -f ...`
+CODE=$(readlink -f "$HOME/src/your_lib")
+
+dkr() {
+  local img=${IMG:-"opendatacube/geobase-builder:latest"}
+  docker run --rm -ti \
+    -v "${CODE}":/code \
+    -v $(pwd):/wk \
+    -e NOBINARY=/wk/nobinary.txt \
+    ${img} \
+    $@
+}
+
+# Download wheels and sources
+dkr env-build-tool download requirements.txt constraints.txt ./wheels
+
+# Compile sources
+dkr env-build-tool compile ./wheels
+
+# Assemble environment
+dkr env-build-tool new_no_index requirements.txt constraints.txt ./env ./wheels
+
+# Install your code in edit mode
+dkr /wk/env/bin/python -m pip install -e /code
+
+# Verify tests can run
+dkr /wk/env/bin/pytest /code
+```


### PR DESCRIPTION
Rather than using `pip wheel --no-binary=...` to download and compile needed libraries, use `pip download --no-binary=` followed by `pip wheel ./<source-lib>.tar.gz`, we can then run several `pip wheel` commands concurrently and only when sources have changed using `make`.

The reason for this change is a limitation of `pip wheel --no-binary=somelib`: `pip` will always recompiled `somelib` because you have requested `no-binary` option for it, this can be really slow for large numeric libraries. With this change it is possible to re-run `download` then `compile` steps much quicker. For a large environment with a lot of `no-binary` libs `download` step can still be slow even if no new libs are fetched as `pip` might need to perform some non-trivial computations to understand library dependencies, but it's more manageable than just `pip wheel --no-binary=...`

With this change it should be possible to leverage github actions cache to significantly speed up test docker building.