### PR TITLE
Switch to buildkit and enable lerc

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -24,6 +24,7 @@ env:
   ORG: opendatacube
   IMAGE: geobase
   IMAGE_DEV: geobase-dev
+  DOCKER_BUILDKIT: 1
 
 
 jobs:

--- a/base/Makefile
+++ b/base/Makefile
@@ -1,0 +1,14 @@
+ORG ?= opendatacube
+TAG ?= latest
+
+dkr: dkr_builder dkr_runner
+
+dkr_builder:
+	DOCKER_BUILDKIT=1 docker build -f builder/Dockerfile -t $(ORG)/geobase-builder:$(TAG) builder
+
+dkr_runner: dkr_builder
+	DOCKER_BUILDKIT=1 docker build -f runner/Dockerfile \
+    --build-arg base=$(ORG)/geobase-builder:$(TAG) \
+    -t $(ORG)/geobase-runner:$(TAG) runner
+
+.PHONY: dkr dkr_builder dkr_runner

--- a/base/builder/gdal.opts
+++ b/base/builder/gdal.opts
@@ -7,8 +7,8 @@ crypto
 libz=internal
 liblzma
 zstd
-libtiff
-geotiff
+libtiff=internal
+geotiff=internal
 jpeg
 png
 gif

--- a/base/runner/Dockerfile
+++ b/base/runner/Dockerfile
@@ -1,3 +1,4 @@
+#syntax=docker/dockerfile:1.2
 ARG base=opendatacube/geobase-builder
 FROM ${base} as builder
 
@@ -51,17 +52,16 @@ RUN apt-get update -y \
   libfreetype6 \
   && rm -rf /var/lib/apt/lists/*
 
-# TODO: we don't really need .deb files polluting this docker image, but alternatives are annoying to use
-#  A. Run http server that would serve *deb packages and fetch from there
-#  B. Copy installed files instead of .deb (need to know which ones)
-#  C. Use experimental docker features: `RUN --mount=type=cache,ro,from=builder,source=/opt,target=/opt ...`
-COPY --from=builder /opt/*deb /opt/
-RUN echo "Installing geo libs" \
-  && dpkg -i /opt/libkea*deb \
-  && dpkg -i /opt/liblerc*deb \
-  && dpkg -i /opt/libproj*deb \
-  && dpkg -i /opt/libgdal*deb \
+RUN --mount=type=bind,from=builder,target=/b \
+  echo "Installing geo libs" \
+  && dpkg -i /b/opt/libkea*deb \
+  && dpkg -i /b/opt/liblerc*deb \
+  && dpkg -i /b/opt/libproj*deb \
+  && dpkg -i /b/opt/libgdal*deb \
   && ldconfig \
+  && cp /b/opt/constraints-gdal.txt /opt/ \
+  && cp /b/opt/compile-wheels.mk /opt/ \
+  && cp /b/usr/local/bin/env-build-tool /usr/local/bin/env-build-tool \
   && echo "Done"
 
 RUN echo "Run smoke test" \


### PR DESCRIPTION
- use buildkit bind mount to avoid copying dpkg into runner
- use internal tiff in order to support LERC compression