### PR TITLE
updates builder and runner to use correct dockerhub images

### DIFF
--- a/.github/workflows/builder-scan.yml
+++ b/.github/workflows/builder-scan.yml
@@ -1,11 +1,12 @@
 name: Builder Scan
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
 env:
-  BUILDER_IMAGE_NAME: opendatacube/geobase:builder
+  BUILDER_IMAGE_NAME: opendatacube/geobase-builder:latest
 jobs:
   builder-cve-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-scan.yml
+++ b/.github/workflows/runner-scan.yml
@@ -1,11 +1,12 @@
 name: Runner Scan
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
 env:
-  RUNNER_IMAGE_NAME: opendatacube/geobase:runner
+  RUNNER_IMAGE_NAME: opendatacube/geobase-runner:latest
 jobs:
   runner-cve-scanner:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What does this PR do?

- Updates the CVE scanning for runner and builder to point to  new DockerHub image locations
- Enables manual workflow trigger for CVE scanning

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)