### PR TITLE
Add deprecation notice to geobase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,9 @@
+# DEPRECATION NOTICE - 2022-02-08
+
+The geobase image is being deprecated and is no longer maintained. Whilst is has been useful to provide a consistent geospatial library build there are now other sources which are more actively maintained that are suitable.
+As an example of the changes necessary to utilise an alternate base image (e.g. `osgeo/gdal`) please see datacube-docker#59
+
+
 opendatacube/geobase
 ====================
 


### PR DESCRIPTION
At the ODC Steering Council Meeting 2022-02-08 it was resolved to Deprecate the geobase image build now that there are other base images which are well maintained in use. This PR has a notification to that effect and links to a PR from datacube-docker which shows how to make changes to use the osgeo as a base image.


Closes #71 